### PR TITLE
📝 docs: convert summaries to hyperlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,16 @@
 ## Usage
 
 1. Use one of the following links to install the theme to your profile:
-   - <details><summary>Latte:</summary><a href="https://themes.ray.so?version=1&name=Catppuccin%20Latte&colors=%23EFF1F5FF,%23EFF1F5FF,%234C4F69FF,%239CA0B0FF,%238C8FA1FF,%23D20F39FF,%23FE640BFF,%23DF8E1DFF,%2340A02BFF,%231E66F5FF,%237287FDFF,%238839EFFF&appearance=light">https://themes.ray.so?version=1&name=Catppuccin%20Latte&colors=%23EFF1F5FF,%23EFF1F5FF,%234C4F69FF,%239CA0B0FF,%238C8FA1FF,%23D20F39FF,%23FE640BFF,%23DF8E1DFF,%2340A02BFF,%231E66F5FF,%237287FDFF,%238839EFFF&appearance=light</a></details">
-   - <details><summary>Frappé:</summary><a href="https://themes.ray.so?version=1&name=Catppuccin%20Frappe&colors=%23303446FF,%23303446FF,%23C6D0F5FF,%23737994FF,%23838BA7FF,%23E78284FF,%23EF9F76FF,%23E5C890FF,%23A6D189FF,%238CAAEEFF,%23BABBF1FF,%23CA9EE6FF&appearance=dark">https://themes.ray.so?version=1&name=Catppuccin%20Frappe&colors=%23303446FF,%23303446FF,%23C6D0F5FF,%23737994FF,%23838BA7FF,%23E78284FF,%23EF9F76FF,%23E5C890FF,%23A6D189FF,%238CAAEEFF,%23BABBF1FF,%23CA9EE6FF&appearance=dark</a></details> 
-   - <details><summary>Macchiato:</summary><a href="https://themes.ray.so?version=1&name=Catppuccin%20Macchiato&colors=%2324273AFF,%2324273AFF,%23CAD3F5FF,%236E738DFF,%238087A2FF,%23ED8796FF,%23F5A97FFF,%23EED49FFF,%23A6DA95FF,%238AADF4FF,%23B7BDF8FF,%23C6A0F6FF&appearance=dark">https://themes.ray.so?version=1&name=Catppuccin%20Macchiato&colors=%2324273AFF,%2324273AFF,%23CAD3F5FF,%236E738DFF,%238087A2FF,%23ED8796FF,%23F5A97FFF,%23EED49FFF,%23A6DA95FF,%238AADF4FF,%23B7BDF8FF,%23C6A0F6FF&appearance=dark</a></details> 
-   - <details><summary>Mocha:</summary><a href="https://themes.ray.so?version=1&name=Catppuccin%20Mocha&colors=%231E1E2EFF,%231E1E2EFF,%23CDD6F4FF,%236C7086FF,%237F849CFF,%23F38BA8FF,%23FAB387FF,%23F9E2AFFF,%23A6E3A1FF,%2389B4FAFF,%23B4BEFEFF,%23CBA6F7FF&appearance=dark">https://themes.ray.so?version=1&name=Catppuccin%20Mocha&colors=%231E1E2EFF,%231E1E2EFF,%23CDD6F4FF,%236C7086FF,%237F849CFF,%23F38BA8FF,%23FAB387FF,%23F9E2AFFF,%23A6E3A1FF,%2389B4FAFF,%23B4BEFEFF,%23CBA6F7FF&appearance=dark</a></details> 
-<!-- this section is optional -->
+   - [🌻 Latte](https://themes.ray.so?version=1&name=Catppuccin%20Latte&colors=%23EFF1F5FF,%23EFF1F5FF,%234C4F69FF,%239CA0B0FF,%238C8FA1FF,%23D20F39FF,%23FE640BFF,%23DF8E1DFF,%2340A02BFF,%231E66F5FF,%237287FDFF,%238839EFFF&appearance=light)
+   - [🪴 Frappé](https://themes.ray.so?version=1&name=Catppuccin%20Frappe&colors=%23303446FF,%23303446FF,%23C6D0F5FF,%23737994FF,%23838BA7FF,%23E78284FF,%23EF9F76FF,%23E5C890FF,%23A6D189FF,%238CAAEEFF,%23BABBF1FF,%23CA9EE6FF&appearance=dark)
+   - [🌺 Macchiato](https://themes.ray.so?version=1&name=Catppuccin%20Macchiato&colors=%2324273AFF,%2324273AFF,%23CAD3F5FF,%236E738DFF,%238087A2FF,%23ED8796FF,%23F5A97FFF,%23EED49FFF,%23A6DA95FF,%238AADF4FF,%23B7BDF8FF,%23C6A0F6FF&appearance=dark)
+   - [🌿 Mocha](https://themes.ray.so?version=1&name=Catppuccin%20Mocha&colors=%231E1E2EFF,%231E1E2EFF,%23CDD6F4FF,%236C7086FF,%237F849CFF,%23F38BA8FF,%23FAB387FF,%23F9E2AFFF,%23A6E3A1FF,%2389B4FAFF,%23B4BEFEFF,%23CBA6F7FF&appearance=dark)
+   <!-- this section is optional -->
+
 ## 🙋 FAQ
 
--	Q: **_"Why do I need Pro to install this theme?"_**\
-	A: Sadly themes need a subscription to Raycast Pro to be enabled.
+- Q: **_"Why do I need Pro to install this theme?"_**\
+  A: Sadly themes need a subscription to Raycast Pro to be enabled.
   It's not ideal, but if you happen to have Raycast Pro these are designed for
   you.
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 </h3>
 
 <p align="center">
-	<a href="https://github.com/rayhanadev/raycast/stargazers"><img src="https://img.shields.io/github/stars/rayhanadev/raycast?colorA=363a4f&colorB=b7bdf8&style=for-the-badge"></a>
-	<a href="https://github.com/rayhanadev/raycast/issues"><img src="https://img.shields.io/github/issues/rayhanadev/raycast?colorA=363a4f&colorB=f5a97f&style=for-the-badge"></a>
-	<a href="https://github.com/rayhanadev/raycast/contributors"><img src="https://img.shields.io/github/contributors/rayhanadev/raycast?colorA=363a4f&colorB=a6da95&style=for-the-badge"></a>
+	<a href="https://github.com/catppuccin/raycast/stargazers"><img src="https://img.shields.io/github/stars/catppuccin/raycast?colorA=363a4f&colorB=b7bdf8&style=for-the-badge"></a>
+	<a href="https://github.com/catppuccin/raycast/issues"><img src="https://img.shields.io/github/issues/catppuccin/raycast?colorA=363a4f&colorB=f5a97f&style=for-the-badge"></a>
+	<a href="https://github.com/catppuccin/raycast/contributors"><img src="https://img.shields.io/github/contributors/catppuccin/raycast?colorA=363a4f&colorB=a6da95&style=for-the-badge"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Hi there! ![](https://cdn.betterttv.net/emote/60730c5439b5010444cfd31d/2x.gif)

I love the port! 

I thought I'd propose using hyperlinks instead of summaries to completely hide the large link parameters. 

### Changes... 

* Convert Summaries to Hyperlinks
* Prepare the repo for transfer
   * for now, all I did was make the badges look at the Catppuccin repo (which is currently nonexistent)