### PR TITLE
refactor: cleanup whiskers template

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,9 @@
 ## Usage
 
 Click one of the following links to install the theme to your profile:
-
 - [🌻 Latte](https://themes.ray.so?version=1&name=Catppuccin%20Latte&colors=%23eff1f5,%23eff1f5,%234c4f69,%239ca0b0,%238c8fa1,%23d20f39,%23fe640b,%23df8e1d,%2340a02b,%231e66f5,%237287fd,%238839ef&appearance=light)
-
 - [🪴 Frappé](https://themes.ray.so?version=1&name=Catppuccin%20Frappé&colors=%23303446,%23303446,%23c6d0f5,%23737994,%23838ba7,%23e78284,%23ef9f76,%23e5c890,%23a6d189,%238caaee,%23babbf1,%23ca9ee6&appearance=dark)
-
 - [🌺 Macchiato](https://themes.ray.so?version=1&name=Catppuccin%20Macchiato&colors=%2324273a,%2324273a,%23cad3f5,%236e738d,%238087a2,%23ed8796,%23f5a97f,%23eed49f,%23a6da95,%238aadf4,%23b7bdf8,%23c6a0f6&appearance=dark)
-
 - [🌿 Mocha](https://themes.ray.so?version=1&name=Catppuccin%20Mocha&colors=%231e1e2e,%231e1e2e,%23cdd6f4,%236c7086,%237f849c,%23f38ba8,%23fab387,%23f9e2af,%23a6e3a1,%2389b4fa,%23b4befe,%23cba6f7&appearance=dark)
 
 ## 🙋 FAQ

--- a/justfile
+++ b/justfile
@@ -2,4 +2,4 @@ _default:
   @just --list
 
 build:
-  whiskers raycast.tera > README.md
+  whiskers raycast.tera

--- a/raycast.tera
+++ b/raycast.tera
@@ -1,6 +1,7 @@
 ---
 whiskers:
-  version: "2.1.0"
+  version: "2.2.0"
+  filename: "README.md"
 ---
 <h3 align="center">
   <img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/logos/exports/1544x1544_circle.png" width="100" alt="Logo"/><br/>
@@ -21,18 +22,10 @@ whiskers:
 
 ## Previews
 
-{%- for id, flavor in flavors %}
+{%- for _, flavor in flavors %}
 <details>
-{%- if id == "latte" %}
-<summary>🌻 Latte</summary>
-{%- elif id == "frappe" %}
-<summary>🪴 Frappé</summary>
-{%- elif id == "macchiato" %}
-<summary>🌺 Macchiato</summary>
-{%- else %}
-<summary>🌿 Mocha</summary>
-{%- endif %}
-<img src="./assets/{{id}}.webp"/>
+<summary>{{ flavor.emoji }} {{ flavor.name }}</summary>
+<img src="./assets/{{ flavor.identifier }}.webp"/>
 </details>
 {%- endfor %}
 
@@ -40,21 +33,9 @@ whiskers:
 
 Click one of the following links to install the theme to your profile:
 
-{%- for id, flavor in flavors -%}
+{%- for _, flavor in flavors -%}
 {%- set palette = flavor.colors %}
-
-{%- if id == "latte" %}
-{%- set emoji = "🌻" %}
-{%- elif id == "frappe" %}
-{%- set emoji = "🪴" %}
-{%- elif id == "macchiato" %}
-{%- set emoji = "🌺" %}
-{%- else %}
-{%- set emoji = "🌿" %}
-{%- endif %}
-
-- [{{ emoji }} {{ flavor.name }}](https://themes.ray.so?version=1&name=Catppuccin%20{{ flavor.name }}&colors=%23{{ palette.base.hex }},%23{{ palette.base.hex }},%23{{ palette.text.hex }},%23{{ palette.overlay0.hex }},%23{{ palette.overlay1.hex }},%23{{ palette.red.hex }},%23{{ palette.peach.hex }},%23{{ palette.yellow.hex }},%23{{ palette.green.hex }},%23{{ palette.blue.hex }},%23{{ palette.lavender.hex }},%23{{ palette.mauve.hex }}&appearance={%- if flavor.dark == true -%}dark{%- else -%}light{%- endif -%})
-
+- [{{ flavor.emoji }} {{ flavor.name }}](https://themes.ray.so?version=1&name=Catppuccin%20{{ flavor.name }}&colors=%23{{ [palette.base, palette.base, palette.text, palette.overlay0, palette.overlay1, palette.red, palette.peach, palette.yellow, palette.green, palette.blue, palette.lavender, palette.mauve] | map(attribute="hex") | join(sep=",%23") }}&appearance={%- if flavor.dark == true -%}dark{%- else -%}light{%- endif -%})
 {%- endfor %}
 
 ## 🙋 FAQ


### PR DESCRIPTION
Removes the redirection in the justfile and has Whiskers write the output itself, adds a trailing newline to the README, utilizes the new `flavor.emoji` property, and maps/joins a list of colors instead of manually spelling them all out.